### PR TITLE
fix password login with a blank username

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class Transmission extends EventEmitter {
     this.url = `${protocol}://${host}:${port}${path}`
     this.key = null
 
-    if (options.username) {
+    if ('username' in options) {
       this.authHeader = 'Basic ' + Base64.encode(options.username + (options.password ? ':' + options.password : ''))
     }
 


### PR DESCRIPTION
my transmission username is a blank string and the loose check caused it to fail login every time